### PR TITLE
Get existed InjectionConfig from cache directly, in order to get working with internal class injecting.

### DIFF
--- a/src/org/swiftsuspenders/Injector.as
+++ b/src/org/swiftsuspenders/Injector.as
@@ -103,6 +103,11 @@ package org.swiftsuspenders
 			}
 			return config;
 		}
+
+		public function getMapped (className:String, named:String = ""):InjectionConfig
+		{
+			return m_mappings[className + '#' + named];
+		}
 		
 		public function injectInto(target : Object) : void
 		{

--- a/src/org/swiftsuspenders/injectionpoints/PropertyInjectionPoint.as
+++ b/src/org/swiftsuspenders/injectionpoints/PropertyInjectionPoint.as
@@ -31,8 +31,8 @@ package org.swiftsuspenders.injectionpoints
 		
 		override public function applyInjection(target : Object, injector : Injector) : Object
 		{
-			var injectionConfig : InjectionConfig = injector.getMapping(Class(
-					injector.getApplicationDomain().getDefinition(_propertyType)), _injectionName);
+			var injectionConfig : InjectionConfig = injector.getMapped(_propertyType, _injectionName)
+												|| injector.getMapping(Class(injector.getApplicationDomain().getDefinition(_propertyType)), _injectionName);
 			var injection : Object = injectionConfig.getResponse(injector);
 			if (injection == null)
 			{

--- a/test/org/swiftsuspenders/InjectorTests.as
+++ b/test/org/swiftsuspenders/InjectorTests.as
@@ -28,6 +28,7 @@ package org.swiftsuspenders
 	
 	import org.swiftsuspenders.support.injectees.ClassInjectee;
 	import org.swiftsuspenders.support.injectees.ComplexClassInjectee;
+	import org.swiftsuspenders.support.injectees.InnerTypeInjectee;
 	import org.swiftsuspenders.support.injectees.InterfaceInjectee;
 	import org.swiftsuspenders.support.injectees.MixedParametersConstructorInjectee;
 	import org.swiftsuspenders.support.injectees.MixedParametersMethodInjectee;
@@ -444,6 +445,14 @@ package org.swiftsuspenders
 //			Assert.assertEquals("Instance field 'property1' should be identical to Instance field 'property2'", injectee.property1, injectee.property2);
 //			Assert.assertEquals("Instance field 'property1' should be identical to Instance field 'namedProperty1'", injectee.property1, injectee.namedProperty1);
 //			Assert.assertEquals("Instance field 'property1' should be identical to Instance field 'namedProperty2'", injectee.property1, injectee.namedProperty2);
+		}
+
+		[Test]
+		public function performInjectionWithInnerType () : void
+		{
+			injector.mapClass(InnerTypeInjectee.innerType, InnerTypeInjectee.innerType);
+			var innerTypeInjectee:InnerTypeInjectee = injector.instantiate(InnerTypeInjectee);
+			Assert.assertNotNull("Inner type should have been injected as well as public type", innerTypeInjectee.property);
 		}
 
 		[Test]

--- a/test/org/swiftsuspenders/support/injectees/InnerTypeInjectee.as
+++ b/test/org/swiftsuspenders/support/injectees/InnerTypeInjectee.as
@@ -1,0 +1,45 @@
+/*
+* Copyright (c) 2009 the original author or authors
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+package org.swiftsuspenders.support.injectees
+{
+
+	public class InnerTypeInjectee
+	{
+
+		public static function get innerType ():Class
+		{
+			return InnerType;
+		}
+
+		[Inject]
+		public var property:InnerType;
+
+	}
+}
+
+
+
+class InnerType
+{
+}
+


### PR DESCRIPTION
Due to the ApplicationDomain.getDefinition() does not work on internal class, it's better to get those Class type reference from cache directly instead of unnecessarily reflection from ApplicationDomain again.

So this code could getting to work nicely:

<pre><code>public function Test ()
{
    var injector:Injector = new Injector();
        injector.mapClass(Item, Item);
            
    var box:Box = injector.instantiate(Box);
        
    trace(box.item);
}

class Box
{
    [Inject] public var item:Item;
}

class Item
{
}</code></pre>


This pull request based on the latest master branch, and I also made the same change on [this branch](https://github.com/imcotton/SwiftSuspenders/tree/fix-on-tag-1.5.1) based on tag 1.5.1, which used by Robotlegs in current version v1.4.0.

Please take a look, thanks for your time.
