### PR TITLE
PostConstruct generalisation

### DIFF
--- a/src/org/swiftsuspenders/Injector.as
+++ b/src/org/swiftsuspenders/Injector.as
@@ -293,7 +293,7 @@ package org.swiftsuspenders
 			
 			//get post construct methods
 			var postConstructMethodPoints : Array = [];
-			for each (node in description.factory.method.metadata.(@name == 'PostConstruct'))
+			for each (node in description..metadata.(@name == 'PostConstruct'))
 			{
 				injectionPoint = new PostConstructInjectionPoint(node, this);
 				postConstructMethodPoints.push(injectionPoint);

--- a/src/org/swiftsuspenders/injectionpoints/PostConstructInjectionPoint.as
+++ b/src/org/swiftsuspenders/injectionpoints/PostConstructInjectionPoint.as
@@ -33,7 +33,7 @@ package org.swiftsuspenders.injectionpoints
 
 		override public function applyInjection(target : Object, injector : Injector) : Object
 		{
-			target[methodName]();
+			target[methodName].call(target)
 			return target;
 		}
 		

--- a/test/org/swiftsuspenders/injectionpoints/PostConstructInjectionPointTests.as
+++ b/test/org/swiftsuspenders/injectionpoints/PostConstructInjectionPointTests.as
@@ -3,6 +3,7 @@ package  org.swiftsuspenders.injectionpoints
 	import org.flexunit.Assert;
 	import org.swiftsuspenders.Injector;
 	import org.swiftsuspenders.support.injectees.ClassInjectee;
+	import org.swiftsuspenders.support.injectees.PostConstructClosureInjectee;
 
 	public class PostConstructInjectionPointTests
 	{
@@ -19,6 +20,15 @@ package  org.swiftsuspenders.injectionpoints
 			
 			Assert.assertTrue(injectee.someProperty);
 		}
+
+		[Test]
+		public function invokePostConstructClosure():void
+		{
+			var injectee:PostConstructClosureInjectee = new PostConstructClosureInjectee();
+			var injector:Injector = new Injector();
+			injector.injectInto(injectee);
+			Assert.assertTrue(injectee.someProperty);
+		}	
 		
 		private function applyPostConstructToClassInjectee():ClassInjectee
 		{

--- a/test/org/swiftsuspenders/injectionpoints/PostConstructInjectionPointTests.as
+++ b/test/org/swiftsuspenders/injectionpoints/PostConstructInjectionPointTests.as
@@ -4,6 +4,7 @@ package  org.swiftsuspenders.injectionpoints
 	import org.swiftsuspenders.Injector;
 	import org.swiftsuspenders.support.injectees.ClassInjectee;
 	import org.swiftsuspenders.support.injectees.PostConstructClosureInjectee;
+	import org.swiftsuspenders.support.injectees.InjectedPostConstructClosureInjectee;
 
 	public class PostConstructInjectionPointTests
 	{
@@ -29,7 +30,21 @@ package  org.swiftsuspenders.injectionpoints
 			injector.injectInto(injectee);
 			Assert.assertTrue(injectee.someProperty);
 		}	
-		
+
+		[Test]
+		public function postConstructCanBeInjected():void
+		{
+			var postConstruct:Function = function():void
+			{
+				this.someProperty = true;
+			}
+			var injectee:InjectedPostConstructClosureInjectee = new InjectedPostConstructClosureInjectee();
+			var injector:Injector = new Injector();
+			injector.mapValue(Function, postConstruct);
+			injector.injectInto(injectee);
+			Assert.assertTrue(injectee.someProperty);
+			
+		}
 		private function applyPostConstructToClassInjectee():ClassInjectee
 		{
 			var injectee:ClassInjectee = new ClassInjectee();

--- a/test/org/swiftsuspenders/support/injectees/InjectedPostConstructClosureInjectee.as
+++ b/test/org/swiftsuspenders/support/injectees/InjectedPostConstructClosureInjectee.as
@@ -1,0 +1,28 @@
+package org.swiftsuspenders.support.injectees
+{
+	/**
+	 * Used in the test that checks if postconstruct works with closures.
+	 * 
+	 * goAtIt should be called by the injector after construction.
+	 * 
+	 * @langversion ActionScript 3
+	 * @playerversion Flash 9.0.0
+	 * 
+	 * @author Lars van de Kerkhof
+	 * @since  15.04.2011
+	 */
+	
+	public class InjectedPostConstructClosureInjectee
+	{
+		public var someProperty:Boolean;
+		
+		public function InjectedPostConstructClosureInjectee()
+		{
+			someProperty = false;
+		}
+		
+		[Inject]
+		[PostConstruct]
+		public var goAtIt:Function;
+	}
+}

--- a/test/org/swiftsuspenders/support/injectees/PostConstructClosureInjectee.as
+++ b/test/org/swiftsuspenders/support/injectees/PostConstructClosureInjectee.as
@@ -1,0 +1,30 @@
+package org.swiftsuspenders.support.injectees
+{
+	/**
+	 * Used in the test that checks if postconstruct works with closures.
+	 * 
+	 * goAtIt should be called by the injector after construction.
+	 * 
+	 * @langversion ActionScript 3
+	 * @playerversion Flash 9.0.0
+	 * 
+	 * @author Lars van de Kerkhof
+	 * @since  15.04.2011
+	 */
+	
+	public class PostConstructClosureInjectee
+	{
+		public var someProperty:Boolean;
+		
+		public function PostConstructClosureInjectee()
+		{
+			someProperty = false;
+		}
+		
+		[PostConstruct]
+		public var goAtIt:Function = function():void
+		{
+			this.someProperty = true;
+		}
+	}
+}


### PR DESCRIPTION
Hi implemented a generalisation of the postconstruct meta tag. Currently it can only be used on methods. I adapted it to also work for function objects. This opens up the following use case:

```
    [Inject]
    [PostConstruct]
    public var initialize:Function;
```

Which means you can map and inject a postconstruct handler, before it is executed.
