### PR TITLE
Configuration xml schema

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -188,7 +188,7 @@ In addition to injection points, @PostConstruct@ method annotations can be speci
 The following example code contains all possible configuration options:
 
 <pre>
-<types>
+<types xmlns="http://github.com/tschneidereit/SwiftSuspenders">
 	<type name='com.example.injectees::FirstInjectee'>
 		<field name='unnamedInjectionPoint'/>
 		<field name='namedInjectionPoint' injectionname='namedInjection'/>
@@ -200,13 +200,13 @@ The following example code contains all possible configuration options:
 		<method name='namedInjectionMethodWithOneArgument' injectionname='namedInjection'/>
 		<method name='namedInjectionMethodWithMultipleArguments'>
 			<arg injectionname='namedInjection'/>
-			<arg injectionname='namedInjection2' injectionname='namedInjection'/>
+			<arg injectionname='namedInjection2'/>
 		</method>
 	</type>
 	<type name='com.example.injectees::ThirdInjectee'>
 		<constructor>
 			<arg injectionname='namedInjection'/>
-			<arg injectionname='namedInjection2' injectionname='namedInjection'/>
+			<arg injectionname='namedInjection2'/>
 		</constructor>
 	</type>
 </types>

--- a/SwiftSuspendersConfigurationSchema.xsd
+++ b/SwiftSuspendersConfigurationSchema.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="http://github.com/tschneidereit/SwiftSuspenders" elementFormDefault="qualified">
+	<xs:element name="types">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="type" minOccurs="0" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="field" minOccurs="0" maxOccurs="unbounded">
+								<xs:complexType>
+									<xs:attribute name="name" type="xs:string" use="required" />
+									<xs:attribute name="injectionname" type="xs:string" use="optional" />
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="postconstruct" minOccurs="0" maxOccurs="unbounded">
+								<xs:complexType>
+									<xs:attribute name="name" type="xs:string" use="required" />
+									<xs:attribute name="order" type="xs:integer" use="optional" />
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="method" minOccurs="0" maxOccurs="unbounded">
+								<xs:complexType>
+									<xs:sequence minOccurs="0" maxOccurs="unbounded">
+										<xs:element name="arg">
+											<xs:complexType>
+												<xs:attribute name="injectionname" type="xs:string" use="required"/>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="name" type="xs:string" use="required" />
+									<xs:attribute name="injectionname" type="xs:string" use="optional" />
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="constructor" minOccurs="0" maxOccurs="1">
+								<xs:complexType>
+									<xs:sequence minOccurs="0" maxOccurs="unbounded">
+										<xs:element name="arg">
+											<xs:complexType>
+												<xs:attribute name="injectionname" type="xs:string" use="required"/>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="name" type="xs:string" use="required"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>


### PR DESCRIPTION
Adding an XML schema file for the validation of injector configuration xml.  Also correcting typo of multiple attributes with the same name on the same node in the README sample configuration xml.

Some users might find it instructional to have a formal description of the acceptable xml used for configuring an injector in addition to the examples.  A schema is also valuable for automated validation of xml artifacts in a build environment.
