### PR TITLE
Added maven support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.settings/*
-
+/target/*
 /html-template/*
 /bin-debug/*
 /bin-release/*

--- a/pom.xml
+++ b/pom.xml
@@ -97,18 +97,4 @@
 			<type>pom</type>
 		</dependency>
 	</dependencies>
-
-	<!--
-		<repositories> <repository> <id>sonotype</id>
-		<url>http://repository.sonatype.org/content/groups/flexgroup</url>
-		<snapshots> <enabled>false</enabled> </snapshots> </repository>
-		</repositories>
-	-->
-
-	<distributionManagement>
-		<repository>
-			<id>oss-repository</id>
-			<url>scpexe://repository.mycompany.com/repository</url>
-		</repository>
-	</distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.swiftsuspenders</groupId>
+	<artifactId>swiftsuspenders</artifactId>
+	<version>1.6.1-SNAPSHOT</version>
+	<packaging>swc</packaging>
+
+	<name>SwiftSuspenders 1.6.1</name>
+	<description>SwiftSuspenders is a basic metadata driven IOC (Inversion Of Control) solution for AS3.</description>
+	<url>https://github.com/tschneidereit/SwiftSuspenders</url>
+	<developers>
+		<developer>
+			<id>tschneidereit</id>
+			<email>tschneidereit@gmail.com</email>
+			<name>Till Schneidereit</name>
+			<timezone>+2</timezone>
+			<roles>
+				<role>owner</role>
+			</roles>
+		</developer>
+	</developers>
+	<licenses>
+		<license>
+			<name>Creative Commons</name>
+			<url>https://github.com/tschneidereit/SwiftSuspenders/blob/master/LICENSE</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+	<scm>
+		<connection>scm:git:git@github.com:tschneidereit/SwiftSuspenders.git</connection>
+		<developerConnection>scm:git:git@github.com:tschneidereit/SwiftSuspenders.git</developerConnection>
+		<url>git@github.com:tschneidereit/SwiftSuspenders.git</url>
+	</scm>
+
+	<properties>
+		<flexunit.version>4.0-rc-1</flexunit.version>
+		<flex.sdk.version>4.0.0.14159</flex.sdk.version>
+	</properties>
+
+	<parent>
+		<groupId>org.sonatype.flexmojos</groupId>
+		<artifactId>flexmojos-flex-super-pom</artifactId>
+		<version>3.8</version>
+	</parent>
+
+	<build>
+		<sourceDirectory>src</sourceDirectory>
+		<testSourceDirectory>test</testSourceDirectory>
+		<plugins>
+			<plugin>
+				<groupId>org.sonatype.flexmojos</groupId>
+				<artifactId>flexmojos-maven-plugin</artifactId>
+				<version>${project.parent.version}</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.adobe.flex</groupId>
+						<artifactId>compiler</artifactId>
+						<version>${flex.sdk.version}</version>
+						<type>pom</type>
+					</dependency>
+				</dependencies>
+				<configuration>
+					<targetPlayer>10.0.0</targetPlayer>
+					<warnings>
+						<noConstructor>false</noConstructor>
+					</warnings>
+					<excludeTestFiles>
+						<excludeTestFile>**/ApplicationDomainTests.as</excludeTestFile>
+					</excludeTestFiles>
+					<includeTestFiles>
+						<includeTestFile>*Test.as</includeTestFile>
+						<includeTestFile>*Tests.as</includeTestFile>
+						<includeTestFile>Test*.as</includeTestFile>
+					</includeTestFiles>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.adobe.flexunit</groupId>
+			<artifactId>flexunit</artifactId>
+			<version>${flexunit.version}</version>
+			<type>swc</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.adobe.flex.framework</groupId>
+			<artifactId>flex-framework</artifactId>
+			<version>${flex.sdk.version}</version>
+			<type>pom</type>
+		</dependency>
+	</dependencies>
+
+	<!--
+		<repositories> <repository> <id>sonotype</id>
+		<url>http://repository.sonatype.org/content/groups/flexgroup</url>
+		<snapshots> <enabled>false</enabled> </snapshots> </repository>
+		</repositories>
+	-->
+
+	<distributionManagement>
+		<repository>
+			<id>oss-repository</id>
+			<url>scpexe://repository.mycompany.com/repository</url>
+		</repository>
+	</distributionManagement>
+</project>


### PR DESCRIPTION
I've added maven support to create builds.  Wasn't sure what to version it, could just change it to master-SNAPSHOT to keep an abstract version.

This POM should help deploy to SwiftSuspenders to OSS repos as an artifact or at least help developers build use SwiftSuspenders locally.
