### PR TITLE
Passes name through to getOrCreateNewInstance

### DIFF
--- a/src/org/swiftsuspenders/Injector.as
+++ b/src/org/swiftsuspenders/Injector.as
@@ -402,9 +402,9 @@ package org.swiftsuspenders
 		 * @throws org.swiftsuspenders.errors.InjectorInterfaceConstructionError if the given type
 		 * is an interface and no mapping was found
 		 */
-		public function getOrCreateNewInstance(type : Class) : *
+		public function getOrCreateNewInstance(type : Class, name : String = '') : *
 		{
-			return satisfies(type) && getInstance(type) || instantiateUnmapped(type);
+			return satisfies(type, name) && getInstance(type, name) || instantiateUnmapped(type);
 		}
 
 		/**


### PR DESCRIPTION
I'm not exactly sure if this makes sense, but it seems like `name` should be passed through to the underlying methods.
