### PR TITLE
Fix when injecting a constructor with several constructor-injected dependencies

### DIFF
--- a/src/org/swiftsuspenders/typedescriptions/MethodInjectionPoint.as
+++ b/src/org/swiftsuspenders/typedescriptions/MethodInjectionPoint.as
@@ -19,8 +19,6 @@ package org.swiftsuspenders.typedescriptions
 	public class MethodInjectionPoint extends InjectionPoint
 	{
 		//----------------------       Private / Protected Properties       ----------------------//
-		private static const _parameterValues : Array = [];
-		
 		protected var _parameterMappingIDs : Array;
 		protected var _requiredParameters : int;
 
@@ -55,7 +53,7 @@ package org.swiftsuspenders.typedescriptions
 				target : Object, targetType : Class, injector : Injector) : Array
 		{
 			var length : int = _parameterMappingIDs.length;
-			var parameters : Array = _parameterValues;
+			var parameters : Array = [];
 			parameters.length = length;
 			for (var i : int = 0; i < length; i++)
 			{

--- a/test/org/swiftsuspenders/InjectorTests.as
+++ b/test/org/swiftsuspenders/InjectorTests.as
@@ -52,6 +52,7 @@ package org.swiftsuspenders
 	import org.swiftsuspenders.support.injectees.TwoNamedParametersConstructorInjectee;
 	import org.swiftsuspenders.support.injectees.TwoNamedParametersMethodInjectee;
 	import org.swiftsuspenders.support.injectees.TwoParametersConstructorInjectee;
+	import org.swiftsuspenders.support.injectees.TwoParameterConstructorInjecteeWithConstructorInjectedDependencies
 	import org.swiftsuspenders.support.injectees.TwoParametersMethodInjectee;
 	import org.swiftsuspenders.support.injectees.UnknownInjectParametersListInjectee;
 	import org.swiftsuspenders.support.injectees.XMLInjectee;
@@ -1119,6 +1120,21 @@ package org.swiftsuspenders
 			Assert.assertEquals("Instance field 'property1' should be identical to Instance field 'property2'", injectee.property1, injectee.property2);
 			Assert.assertEquals("Instance field 'property1' should be identical to Instance field 'namedProperty1'", injectee.property1, injectee.namedProperty1);
 			Assert.assertEquals("Instance field 'property1' should be identical to Instance field 'namedProperty2'", injectee.property1, injectee.namedProperty2);
+		}
+
+
+		[Test]
+		public function two_parameter_constructor_injection_with_constructor_injected_dependencies_fulfilled():void
+		{
+			injector.map(Clazz);
+			injector.map(OneParameterConstructorInjectee);
+			injector.map(TwoParametersConstructorInjectee);
+			injector.map(String).toValue('stringDependency');
+
+			var injectee:TwoParameterConstructorInjecteeWithConstructorInjectedDependencies = 
+				injector.instantiateUnmapped(TwoParameterConstructorInjecteeWithConstructorInjectedDependencies);
+			Assert.assertNotNull("Instance of Class should have been injected for OneParameterConstructorInjectee parameter", injectee.getDependency1() );
+			Assert.assertNotNull("Instance of Class should have been injected for TwoParametersConstructorInjectee parameter", injectee.getDependency1() );
 		}
 
 		//		[Test]

--- a/test/org/swiftsuspenders/support/injectees/TwoParameterConstructorInjecteeWithConstructorInjectedDependencies.as
+++ b/test/org/swiftsuspenders/support/injectees/TwoParameterConstructorInjecteeWithConstructorInjectedDependencies.as
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2009 the original author or authors
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+package org.swiftsuspenders.support.injectees
+{
+	import org.swiftsuspenders.support.types.Clazz;
+
+	public class TwoParameterConstructorInjecteeWithConstructorInjectedDependencies
+	{
+		private var m_dependency1 : OneParameterConstructorInjectee;
+		private var m_dependency2 : TwoParametersConstructorInjectee;
+		
+		public function getDependency1() : OneParameterConstructorInjectee
+		{
+			return m_dependency1;
+		}
+		
+		
+		public function getDependency2():TwoParametersConstructorInjectee
+		{
+			return m_dependency2;
+		}
+
+		
+		public function TwoParameterConstructorInjecteeWithConstructorInjectedDependencies(dependency1:OneParameterConstructorInjectee,
+			dependency2:TwoParametersConstructorInjectee)
+		{
+			m_dependency1 = dependency1;
+			m_dependency2 = dependency2;
+		}
+	}
+}


### PR DESCRIPTION
A global Array _parameterValues was used in MethodInjectionPoint.as, so
that during recursive calls of applyInjection, its content would get
clobbered and resolved dependencies replaced with null for the outer
injection.

A test exposing the defect was also added (at the end of InjectorTests).

PS: for some reason github shows the diff as full file diffs, even though I took great care not to apply formatting tools - I even checked the files in an hex editor, and they seem identical except for my specific changes. Not being very experienced with either git or GitHub I could not figure how to prevent that; I hope it does not complicate merging too much.
